### PR TITLE
feature/fix_dind_version

### DIFF
--- a/charts/dind/Chart.yaml
+++ b/charts/dind/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dind
 description: dind helm chart
-version: 1.1.0
+version: 1.1.1
 dependencies:
 - name: generic
   version: 1.2.1

--- a/charts/dind/values.yaml
+++ b/charts/dind/values.yaml
@@ -6,7 +6,7 @@ generic:
       image:
         repository: docker
         pullPolicy: Always
-        tag: dind
+        tag: 19-dind
       # args: [ "--mtu=1450" ]
       ports:
         - containerPort: 2375

--- a/charts/kool/Chart.yaml
+++ b/charts/kool/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
   repository: https://charts.kool.dev
 - name: dind
   condition: dind.enabled
-  version: 1.1.0
+  version: 1.1.1
   repository: https://charts.kool.dev


### PR DESCRIPTION
Fix version find. 
Actualmente we have an error with version 20.
`docker: Error response from daemon: io.containerd.runc.v2: failed to adjust OOM score for shim: set shim OOM score: write /proc/286/oom_score_adj: invalid argument`